### PR TITLE
Add minimal Haxe CLI converter skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+bin/
+sample.js

--- a/build-cli.hxml
+++ b/build-cli.hxml
@@ -1,0 +1,4 @@
+-cp src
+-main cli.Main
+-neko bin/cli.n
+-dce full

--- a/haxelib.json
+++ b/haxelib.json
@@ -1,0 +1,10 @@
+{
+  "name": "HaxeCodeConvert",
+  "license": "MIT",
+  "tags": ["code", "convert", "ast"],
+  "description": "Simplified demo code converter with pivot AST.",
+  "version": "0.0.1",
+  "classPath": "src",
+  "contributors": ["OpenAI-Assistant"],
+  "dependencies": {}
+}

--- a/src/ai/IAgent.hx
+++ b/src/ai/IAgent.hx
@@ -1,0 +1,5 @@
+package ai;
+
+interface IAgent {
+  public function convertChunk(code:String, from:String, to:String):String;
+}

--- a/src/ai/NullAgent.hx
+++ b/src/ai/NullAgent.hx
@@ -1,0 +1,8 @@
+package ai;
+
+class NullAgent implements IAgent {
+  public function new() {}
+  public function convertChunk(code:String, from:String, to:String):String {
+    return code;
+  }
+}

--- a/src/cli/Main.hx
+++ b/src/cli/Main.hx
@@ -1,0 +1,34 @@
+package cli;
+
+import core.Converter;
+import core.Language;
+import ai.NullAgent;
+
+class Main {
+  static function usage() {
+    Sys.println('Usage: convert --from=<src> --to=<dst> [input-file]');
+    Sys.exit(1);
+  }
+
+  public static function main() {
+    var from:Language = Language.Auto;
+    var to:Language = Language.Python;
+    var input:String = null;
+
+    for (arg in Sys.args()) {
+      if (StringTools.startsWith(arg, "--from=")) from = Language.normalize(arg.substr(7));
+      else if (StringTools.startsWith(arg, "--to=")) to = Language.normalize(arg.substr(5));
+      else if (!StringTools.startsWith(arg, "--")) input = arg;
+    }
+
+    if (input == null) {
+      usage();
+      return;
+    }
+
+    var code = sys.io.File.getContent(input);
+    var conv = new Converter(new NullAgent());
+    var out = conv.convert(code, from, to);
+    Sys.print(out);
+  }
+}

--- a/src/core/Converter.hx
+++ b/src/core/Converter.hx
@@ -1,0 +1,41 @@
+package core;
+
+import ai.IAgent;
+import StringTools;
+
+class Converter {
+  var agent:IAgent;
+  public function new(agent:IAgent) {
+    this.agent = agent;
+  }
+
+  public function convert(code:String, from:Language, to:Language):String {
+    var src = from == Language.Auto ? detectLanguage(code) : from;
+    if (src == to) return code;
+    if (src == Language.JavaScript && to == Language.Python) {
+      return jsToPython(code);
+    }
+    return agent.convertChunk(code, cast src, cast to);
+  }
+
+  function detectLanguage(code:String):Language {
+    if (~/^\s*def /m.match(code) || ~/^\s*print\(/m.match(code)) return Language.Python;
+    if (~/^\s*function /m.match(code) || ~/console\.log/.match(code)) return Language.JavaScript;
+    return Language.Auto;
+  }
+
+  function jsToPython(code:String):String {
+    var lines = code.split("\n");
+    var out:Array<String> = [];
+    for (line in lines) {
+      var l = StringTools.replace(line, "console.log", "print");
+      l = ~/;\s*$/.replace(l, "");
+      if (~/function\s+([a-zA-Z0-9_]+)\(([^)]*)\)\s*{/.match(l)) {
+        l = ~/function\s+([a-zA-Z0-9_]+)\(([^)]*)\)\s*{/.replace(l, "def $1($2):");
+      }
+      if (l.indexOf("}") >= 0) continue;
+      out.push(l);
+    }
+    return out.join("\n");
+  }
+}

--- a/src/core/Language.hx
+++ b/src/core/Language.hx
@@ -1,0 +1,17 @@
+package core;
+
+enum abstract Language(String) {
+  var Auto = "auto";
+  var JavaScript = "javascript";
+  var Python = "python";
+  var Haxe = "haxe";
+
+  public static function normalize(id:String):Language {
+    switch(id.toLowerCase()) {
+      case "javascript" | "js": return JavaScript;
+      case "python" | "py": return Python;
+      case "haxe": return Haxe;
+      default: return Auto;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add minimal Haxe project skeleton with CLI entry point
- support enum-based language normalization
- implement basic JavaScript→Python converter and agent interface

## Testing
- `haxe build-cli.hxml`
- `neko bin/cli.n --from=javascript --to=python sample.js`

------
https://chatgpt.com/codex/tasks/task_e_68a75adc0f64832b8a1e30043b27e7d0