### PR TITLE
Add registry and segmenter stubs

### DIFF
--- a/src/core/Registry.hx
+++ b/src/core/Registry.hx
@@ -1,0 +1,41 @@
+package core;
+
+import core.Language;
+
+typedef Parser = {
+  function parseSegment(text:String):Dynamic;
+}
+
+typedef Emitter = {
+  function emit(ast:Dynamic):String;
+}
+
+class Registry {
+  static var parsers:Map<Language, Parser> = new Map();
+  static var emitters:Map<Language, Emitter> = new Map();
+
+  public static function initDefaults():Void {
+    if (!parsers.exists(Language.JavaScript)) {
+      parsers.set(Language.JavaScript, {
+        parseSegment: function(text:String):Dynamic {
+          return text;
+        }
+      });
+    }
+    if (!emitters.exists(Language.Python)) {
+      emitters.set(Language.Python, {
+        emit: function(ast:Dynamic):String {
+          return Std.string(ast);
+        }
+      });
+    }
+  }
+
+  public static function getParser(lang:Language):Parser {
+    return parsers.get(lang);
+  }
+
+  public static function getEmitter(lang:Language):Emitter {
+    return emitters.get(lang);
+  }
+}

--- a/src/core/Segmenter.hx
+++ b/src/core/Segmenter.hx
@@ -1,0 +1,7 @@
+package core;
+
+class Segmenter {
+  public static function split(code:String):Array<{text:String}> {
+    return [{ text: code }];
+  }
+}


### PR DESCRIPTION
## Summary
- add registry to manage parser/emitter defaults
- add simple segmenter for splitting code

## Testing
- `haxe build-cli.hxml`

------
https://chatgpt.com/codex/tasks/task_e_68a770391454832bae8c03061efb5984