### PR TITLE
refactor: hierarchical AST

### DIFF
--- a/src/core/UniAst.hx
+++ b/src/core/UniAst.hx
@@ -1,5 +1,41 @@
 package core;
 
+/**
+ * Root of the universal abstract syntax tree.
+ * A module is composed of one or more blocks.
+ */
 typedef UniAstModule = {
-  var lines:Array<String>;
+  /** Blocks contained in the module. */
+  var blocks:Array<UniAstBlock>;
 }
+
+/**
+ * A block groups a sequence of instructions.
+ */
+typedef UniAstBlock = {
+  /** Instructions that appear in the block. */
+  var instructions:Array<UniAstInstruction>;
+}
+
+/**
+ * Represents a single instruction of the language.
+ */
+enum UniAstInstruction {
+  /** Declaration of a function with its name, parameters and body. */
+  FunctionDecl(name:String, params:Array<String>, body:UniAstBlock);
+  /** An instruction consisting solely of an expression. */
+  Expr(expr:UniAstExpr);
+  /** Return statement returning the given expression. */
+  Return(expr:UniAstExpr);
+}
+
+/**
+ * Different kinds of expressions.
+ */
+enum UniAstExpr {
+  /** String literal value. */
+  StringLiteral(value:String);
+  /** Function call with a name and arguments. */
+  CallExpr(name:String, args:Array<UniAstExpr>);
+}
+

--- a/src/emitters/PythonEmitter.hx
+++ b/src/emitters/PythonEmitter.hx
@@ -8,15 +8,35 @@ class PythonEmitter implements IEmitter {
 
   public function emit(ast:UniAstModule):String {
     var out:Array<String> = [];
-    for (l in ast.lines) {
-      var line = StringTools.replace(l, "console.log", "print");
-      line = ~/;\s*$/.replace(line, "");
-      if (~/function\s+([a-zA-Z0-9_]+)\(([^)]*)\)\s*{/.match(line)) {
-        line = ~/function\s+([a-zA-Z0-9_]+)\(([^)]*)\)\s*{/.replace(line, "def $1($2):");
+    for (block in ast.blocks) {
+      for (inst in block.instructions) {
+        emitInstruction(inst, out, 0);
       }
-      if (line.indexOf("}") >= 0) continue;
-      out.push(line);
     }
     return out.join("\n");
+  }
+
+  function emitInstruction(inst:UniAstInstruction, out:Array<String>, indent:Int):Void {
+    var pad = StringTools.lpad("", " ", indent);
+    switch (inst) {
+      case FunctionDecl(name, params, body):
+        out.push(pad + "def " + name + "(" + params.join(", ") + "):");
+        for (sub in body.instructions) {
+          emitInstruction(sub, out, indent + 2);
+        }
+      case Expr(expr):
+        out.push(pad + emitExpr(expr));
+      case Return(expr):
+        out.push(pad + "return " + emitExpr(expr));
+    }
+  }
+
+  function emitExpr(e:UniAstExpr):String {
+    return switch (e) {
+      case StringLiteral(v): '"' + v + '"';
+      case CallExpr(name, args):
+        var pyName = (name == "console.log") ? "print" : name;
+        pyName + "(" + args.map(emitExpr).join(", ") + ")";
+    }
   }
 }

--- a/src/parsers/JSParser.hx
+++ b/src/parsers/JSParser.hx
@@ -1,11 +1,73 @@
 package parsers;
 
 import core.UniAst;
+import StringTools;
 
 class JSParser implements IParser {
   public function new() {}
 
   public function parse(code:String):UniAstModule {
-    return { lines: code.split("\n") };
+    var lines = code.split("\n");
+    var instructions = new Array<UniAstInstruction>();
+    var i = 0;
+    while (i < lines.length) {
+      var line = StringTools.trim(lines[i]);
+      if (line == "" || line == "}") {
+        i++;
+        continue;
+      }
+      var funcRe = ~/^function\s+([a-zA-Z0-9_]+)\(([^)]*)\)\s*{/;
+      if (funcRe.match(line)) {
+        var name = funcRe.matched(1);
+        var params = funcRe.matched(2).split(",").map(StringTools.trim).filter(function(p) return p != "");
+        i++;
+        var bodyLines = [];
+        while (i < lines.length && lines[i].indexOf("}") < 0) {
+          bodyLines.push(lines[i]);
+          i++;
+        }
+        var bodyBlock = { instructions: parseBlock(bodyLines) };
+        instructions.push(FunctionDecl(name, params, bodyBlock));
+        i++; // skip closing brace
+        continue;
+      }
+      instructions.push(parseInstruction(line));
+      i++;
+    }
+    return { blocks: [ { instructions: instructions } ] };
+  }
+
+  function parseBlock(lines:Array<String>):Array<UniAstInstruction> {
+    var out = new Array<UniAstInstruction>();
+    for (l in lines) {
+      var t = StringTools.trim(l);
+      if (t == "") continue;
+      out.push(parseInstruction(t));
+    }
+    return out;
+  }
+
+  function parseInstruction(line:String):UniAstInstruction {
+    var returnRe = ~/^return\s+(.+)/;
+    if (returnRe.match(line)) {
+      var expr = parseExpr(returnRe.matched(1));
+      return Return(expr);
+    }
+    return Expr(parseExpr(line));
+  }
+
+  function parseExpr(text:String):UniAstExpr {
+    text = ~/;\s*$/.replace(StringTools.trim(text), "");
+    var callRe = ~/^([a-zA-Z0-9_\.]+)\((.*)\)$/;
+    if (callRe.match(text)) {
+      var name = callRe.matched(1);
+      var argsText = StringTools.trim(callRe.matched(2));
+      var args = (argsText == "") ? [] : argsText.split(",").map(function(a) return parseExpr(StringTools.trim(a)));
+      return CallExpr(name, args);
+    }
+    if (text.length >= 2 && StringTools.startsWith(text, "\"") && StringTools.endsWith(text, "\"")) {
+      return StringLiteral(text.substr(1, text.length - 2));
+    }
+    return StringLiteral(text);
   }
 }


### PR DESCRIPTION
## Summary
- replace flat UniAstModule with hierarchical modules, blocks, instructions and expressions
- document AST nodes
- update JS parser and Python emitter to build and consume new AST

## Testing
- `haxe -v build-cli.hxml`


------
https://chatgpt.com/codex/tasks/task_e_68a778025978832b9ac12f7baf296fcc