### PR TITLE
refactor: unify JS→Python conversion pipeline

### DIFF
--- a/src/core/UniAst.hx
+++ b/src/core/UniAst.hx
@@ -35,6 +35,10 @@ enum UniAstInstruction {
 enum UniAstExpr {
   /** String literal value. */
   StringLiteral(value:String);
+  /** Identifier usage. */
+  Identifier(name:String);
+  /** Numeric literal value. */
+  NumberLiteral(value:String);
   /** Function call with a name and arguments. */
   CallExpr(name:String, args:Array<UniAstExpr>);
 }

--- a/src/emitters/PythonEmitter.hx
+++ b/src/emitters/PythonEmitter.hx
@@ -34,6 +34,8 @@ class PythonEmitter implements IEmitter {
   function emitExpr(e:UniAstExpr):String {
     return switch (e) {
       case StringLiteral(v): '"' + v + '"';
+      case Identifier(name): name;
+      case NumberLiteral(v): v;
       case CallExpr(name, args):
         var pyName = (name == "console.log") ? "print" : name;
         pyName + "(" + args.map(emitExpr).join(", ") + ")";

--- a/src/parsers/JSParser.hx
+++ b/src/parsers/JSParser.hx
@@ -51,6 +51,10 @@ class JSParser implements IParser {
       case "string":
         var t = node.text;
         StringLiteral(t.substr(1, t.length - 2));
+      case "identifier":
+        Identifier(node.text);
+      case "number":
+        NumberLiteral(node.text);
       default:
         StringLiteral(node.text);
     }


### PR DESCRIPTION
## Summary
- Remove `jsToPython` shortcut and rely on parser + emitter or AI fallback
- Extend `UniAst` and parser/emitter to handle identifiers and numbers
- Use Python emitter for all JS→Python transformation

## Testing
- `haxe test.hxml`

------
https://chatgpt.com/codex/tasks/task_e_68a77abd4b30832ba5470889120d093e