### PR TITLE
Add stubs for CSharp, Java, and Go languages

### DIFF
--- a/src/core/Language.hx
+++ b/src/core/Language.hx
@@ -5,12 +5,18 @@ enum abstract Language(String) {
   var JavaScript = "javascript";
   var Python = "python";
   var Haxe = "haxe";
+  var CSharp = "csharp";
+  var Java = "java";
+  var Go = "go";
 
   public static function normalize(id:String):Language {
     switch(id.toLowerCase()) {
       case "javascript" | "js": return JavaScript;
       case "python" | "py": return Python;
       case "haxe": return Haxe;
+      case "csharp" | "c#" | "cs": return CSharp;
+      case "java": return Java;
+      case "go" | "golang": return Go;
       default: return Auto;
     }
   }

--- a/src/core/Registry.hx
+++ b/src/core/Registry.hx
@@ -2,8 +2,14 @@ package core;
 
 import parsers.IParser;
 import parsers.JSParser;
+import parsers.CSharpParser;
+import parsers.JavaParser;
+import parsers.GoParser;
 import emitters.IEmitter;
 import emitters.PythonEmitter;
+import emitters.CSharpEmitter;
+import emitters.JavaEmitter;
+import emitters.GoEmitter;
 
 /**
  * Global registry for parser and emitter implementations.
@@ -21,6 +27,15 @@ class Registry {
     initialized = true;
     registerParser(Language.JavaScript, new JSParser());
     registerEmitter(Language.Python, new PythonEmitter());
+
+    registerParser(Language.CSharp, new CSharpParser());
+    registerEmitter(Language.CSharp, new CSharpEmitter());
+
+    registerParser(Language.Java, new JavaParser());
+    registerEmitter(Language.Java, new JavaEmitter());
+
+    registerParser(Language.Go, new GoParser());
+    registerEmitter(Language.Go, new GoEmitter());
   }
 
   public static function registerParser(lang:Language, parser:IParser):Void {

--- a/src/emitters/CSharpEmitter.hx
+++ b/src/emitters/CSharpEmitter.hx
@@ -1,0 +1,12 @@
+package emitters;
+
+import core.UniAst;
+import emitters.EmitterError;
+
+class CSharpEmitter implements IEmitter {
+  public function new() {}
+
+  public function emit(ast:UniAstModule):String {
+    throw new EmitterError("C# emitting not implemented");
+  }
+}

--- a/src/emitters/EmitterError.hx
+++ b/src/emitters/EmitterError.hx
@@ -1,0 +1,7 @@
+package emitters;
+
+class EmitterError extends haxe.Exception {
+  public function new(msg:String) {
+    super(msg);
+  }
+}

--- a/src/emitters/GoEmitter.hx
+++ b/src/emitters/GoEmitter.hx
@@ -1,0 +1,12 @@
+package emitters;
+
+import core.UniAst;
+import emitters.EmitterError;
+
+class GoEmitter implements IEmitter {
+  public function new() {}
+
+  public function emit(ast:UniAstModule):String {
+    throw new EmitterError("Go emitting not implemented");
+  }
+}

--- a/src/emitters/JavaEmitter.hx
+++ b/src/emitters/JavaEmitter.hx
@@ -1,0 +1,12 @@
+package emitters;
+
+import core.UniAst;
+import emitters.EmitterError;
+
+class JavaEmitter implements IEmitter {
+  public function new() {}
+
+  public function emit(ast:UniAstModule):String {
+    throw new EmitterError("Java emitting not implemented");
+  }
+}

--- a/src/parsers/CSharpParser.hx
+++ b/src/parsers/CSharpParser.hx
@@ -1,0 +1,12 @@
+package parsers;
+
+import core.UniAst;
+import parsers.ParserError;
+
+class CSharpParser implements IParser {
+  public function new() {}
+
+  public function parse(code:String):UniAstModule {
+    throw new ParserError("C# parsing not implemented");
+  }
+}

--- a/src/parsers/GoParser.hx
+++ b/src/parsers/GoParser.hx
@@ -1,0 +1,12 @@
+package parsers;
+
+import core.UniAst;
+import parsers.ParserError;
+
+class GoParser implements IParser {
+  public function new() {}
+
+  public function parse(code:String):UniAstModule {
+    throw new ParserError("Go parsing not implemented");
+  }
+}

--- a/src/parsers/JavaParser.hx
+++ b/src/parsers/JavaParser.hx
@@ -1,0 +1,12 @@
+package parsers;
+
+import core.UniAst;
+import parsers.ParserError;
+
+class JavaParser implements IParser {
+  public function new() {}
+
+  public function parse(code:String):UniAstModule {
+    throw new ParserError("Java parsing not implemented");
+  }
+}


### PR DESCRIPTION
## Summary
- Extend language enumeration with CSharp, Java, and Go options
- Provide parser and emitter stubs for the new languages with clear error messages
- Register the new language/parser/emitter pairs in the default registry

## Testing
- `haxe test.hxml && node bin/test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a77bf66e2c832bb3b77da71c623e47