### PR TITLE
Handle required CLI options and add argument parsing tests

### DIFF
--- a/src/cli/Main.hx
+++ b/src/cli/Main.hx
@@ -5,29 +5,55 @@ import core.Language;
 import ai.NullAgent;
 
 class Main {
-  static function usage() {
+#if sys
+  static function usage(?code:Int = 0) {
     Sys.println('Usage: convert --from=<src> --to=<dst> [--out=FILE] [input-file]');
-    Sys.exit(1);
+    Sys.exit(code);
   }
+#end
 
-  public static function main() {
-    var from:Language = Language.Auto;
-    var to:Language = Language.Python;
+  public static function parseArgs(args:Array<String>):{
+    var from:Null<Language>;
+    var to:Null<Language>;
+    var input:Null<String>;
+    var output:Null<String>;
+    var help:Bool;
+  } {
+    var from:Null<Language> = null;
+    var to:Null<Language> = null;
     var input:Null<String> = null;
     var output:Null<String> = null;
+    var help = false;
 
-    for (arg in Sys.args()) {
-      if (StringTools.startsWith(arg, "--from=")) from = Language.normalize(arg.substr(7));
+    for (arg in args) {
+      if (arg == "--help" || arg == "-h") help = true;
+      else if (StringTools.startsWith(arg, "--from=")) from = Language.normalize(arg.substr(7));
       else if (StringTools.startsWith(arg, "--to=")) to = Language.normalize(arg.substr(5));
       else if (StringTools.startsWith(arg, "--out=")) output = arg.substr(6);
       else if (!StringTools.startsWith(arg, "--")) input = arg;
     }
 
-    var code = (input != null) ? sys.io.File.getContent(input) : Sys.stdin().readAll().toString();
-    var conv = new Converter(new NullAgent());
-    var out = conv.convert(code, from, to);
+    return {
+      from: from,
+      to: to,
+      input: input,
+      output: output,
+      help: help
+    };
+  }
 
-    if (output != null) sys.io.File.saveContent(output, out);
+#if sys
+  public static function main() {
+    var opts = parseArgs(Sys.args());
+    if (opts.help) usage(0);
+    if (opts.from == null || opts.to == null) usage(1);
+
+    var code = (opts.input != null) ? sys.io.File.getContent(opts.input) : Sys.stdin().readAll().toString();
+    var conv = new Converter(new NullAgent());
+    var out = conv.convert(code, opts.from, opts.to);
+
+    if (opts.output != null) sys.io.File.saveContent(opts.output, out);
     else Sys.print(out);
   }
+#end
 }

--- a/test/TestMain.hx
+++ b/test/TestMain.hx
@@ -2,9 +2,11 @@ package test;
 
 import parsers.JSParser;
 import parsers.ParserError;
+import cli.Main;
+import core.Language;
 
 class TestMain {
-  static function main() {
+  static function testParser() {
     var parser = new JSParser();
     var ast = parser.parse('function hi(name){ return call("x"); }');
     if (ast.blocks.length != 1 || ast.blocks[0].instructions.length != 1) {
@@ -17,6 +19,22 @@ class TestMain {
       failed = true;
     }
     if (!failed) throw 'Expected parse error';
+  }
+
+  static function testCliArgs() {
+    var opts = Main.parseArgs(["--from=js", "--to=python", "input.txt"]);
+    if (opts.from != Language.JavaScript) throw 'from not parsed';
+    if (opts.to != Language.Python) throw 'to not parsed';
+    if (opts.input != "input.txt") throw 'input not parsed';
+    var helpOpts = Main.parseArgs(["-h"]);
+    if (!helpOpts.help) throw 'help flag not detected';
+    var missing = Main.parseArgs(["--from=js"]);
+    if (missing.to != null) throw 'missing to not detected';
+  }
+
+  static function main() {
+    testParser();
+    testCliArgs();
     trace('tests passed');
   }
 }


### PR DESCRIPTION
## Summary
- Add help flag and mandatory `--from`/`--to` validation for the CLI
- Expose `parseArgs` to parse command-line options
- Test argument analysis including help flag and missing options

## Testing
- `haxe test.hxml && node bin/test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a77d0af08c832b9346f1ed881593b5