### PR TITLE
Fix GUI compile errors by updating HaxeUI usage

### DIFF
--- a/src/gui/Main.hx
+++ b/src/gui/Main.hx
@@ -26,10 +26,10 @@ class Main extends Sprite {
     root.percentWidth = 100;
     root.percentHeight = 100;
     root.padding = 10;
-    root.gap = 8;
+    root.spacing = 8;
 
     var top = new HBox();
-    top.gap = 10;
+    top.spacing = 10;
 
     fromSel = new DropDown();
     fromSel.dataSource = langData();
@@ -58,9 +58,13 @@ class Main extends Sprite {
       statusLbl.text = "";
     };
 
-    top.addComponent(new Label("From:"));
+    var fromLbl = new Label();
+    fromLbl.text = "From:";
+    top.addComponent(fromLbl);
     top.addComponent(fromSel);
-    top.addComponent(new Label("To:"));
+    var toLbl = new Label();
+    toLbl.text = "To:";
+    top.addComponent(toLbl);
     top.addComponent(toSel);
     top.addComponent(convertBtn);
     top.addComponent(swapBtn);
@@ -74,7 +78,7 @@ class Main extends Sprite {
     outputArea = new TextArea();
     outputArea.percentWidth = 100;
     outputArea.percentHeight = 45;
-    outputArea.readonly = true;
+    outputArea.readOnly = true;
 
     root.addComponent(top);
     root.addComponent(inputArea);


### PR DESCRIPTION
## Summary
- replace deprecated `gap` property with `spacing` in `VBox` and `HBox`
- avoid passing text to `Label` constructor and set label text explicitly
- use `readOnly` property for output text area

## Testing
- `npm test` *(fails: Library utest is not installed)*
- `haxelib install utest -y` *(fails: Failed to connect on lib.haxe.org:443)*
- `haxelib run openfl test project.xml neko` *(fails: Library openfl is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a78520bfc4832bbd0b2be9895e338c